### PR TITLE
Modify global io references for module usage

### DIFF
--- a/dist/angular-sails.js
+++ b/dist/angular-sails.js
@@ -71,7 +71,7 @@ angular.module('ngSails', ['ng']);
         // like https://docs.angularjs.org/api/ng/service/$http#interceptors
         // but with sails.io arguments
         var interceptorFactories = this.interceptors = [
-            /*function($injectables) {
+          /*function($injectables) {
                 return {
                     request: function(config) {},
                     response: function(response) {},
@@ -83,7 +83,7 @@ angular.module('ngSails', ['ng']);
 
         /*@ngInject*/
         this.$get = ["$q", "$injector", "$rootScope", "$log", "$timeout", function($q, $injector, $rootScope, $log, $timeout) {
-            var socket = (io.sails && io.sails.connect || io.connect)(provider.url, provider.config);
+            var socket = window.io.sails.connect(provider.url, provider.config);
 
             socket.connect = function(opts){
                 if(!socket.isConnected()){


### PR DESCRIPTION
This change explicitly references the `io` object as a property of `window` which enables it for usage in modules. Put inversely, this prevents minification of `io` object.