### PR TITLE
Add already-connected check

### DIFF
--- a/dist/angular-sails.js
+++ b/dist/angular-sails.js
@@ -1,10 +1,11 @@
-(function (angular, io) {
+(function (angular) {
 'use strict'/*global angular */
 angular.module('ngSails', ['ng']);
 
 /*global angular, io */
-(function(angular, io) {
+(function(angular) {
     'use strict';
+    var io = window.io;
     if(io.sails){
       io.sails.autoConnect = false;
     }
@@ -309,5 +310,5 @@ angular.module('ngSails', ['ng']);
         }];
         this.$get.$inject = ["$q", "$injector", "$rootScope", "$log", "$timeout"];
     });
-}(angular, io));
-}(angular, io));
+}(angular));
+}(angular));

--- a/src/service/angular-sails.js
+++ b/src/service/angular-sails.js
@@ -1,6 +1,7 @@
-/*global angular, io */
-(function(angular, io) {
+/*global angular*/
+(function(angular) {
     'use strict';
+    var io = window.io;
     if(io.sails){
       io.sails.autoConnect = false;
     }
@@ -79,7 +80,7 @@
 
         /*@ngInject*/
         this.$get = function($q, $injector, $rootScope, $log, $timeout) {
-            var socket = (io.sails && io.sails.connect || io.connect)(provider.url, provider.config);
+            var socket = window.io.socket || window.io.sails.connect(provider.url, provider.config);
 
             socket.connect = function(opts){
                 if(!socket.isConnected()){
@@ -304,4 +305,4 @@
             return socket;
         };
     });
-}(angular, io));
+}(angular));


### PR DESCRIPTION
This change will prevent websocket connections from being made when `socket` already exists on the `io` global